### PR TITLE
don't show url for external link in epub file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -243,3 +243,6 @@ texinfo_documents = [
 
 # code highlight setting
 highlight_language = 'cl'
+
+# How to display URL addresses: 'footnote', 'no', or 'inline'.
+epub_show_urls = 'no'


### PR DESCRIPTION
epub格式下外链默认显示了url，非常干扰阅读，可以通过epub_show_urls来配置
显示样式